### PR TITLE
Multiple code improvements - squid:S1192, squid:CommentedOutCodeLine, squid:S1213

### DIFF
--- a/app/src/main/java/computician/janusclient/EchoTest.java
+++ b/app/src/main/java/computician/janusclient/EchoTest.java
@@ -53,8 +53,6 @@ public class EchoTest {
 
         @Override
         public List<PeerConnection.IceServer> getIceServers() {
-            //ArrayList<PeerConnection.IceServer> iceServers =
-            //iceServers.add(new PeerConnection.IceServer("stun:stun.l.google.com:19302"));
             return new ArrayList<PeerConnection.IceServer>();
         }
 

--- a/app/src/main/java/computician/janusclient/JanusActivity.java
+++ b/app/src/main/java/computician/janusclient/JanusActivity.java
@@ -54,12 +54,6 @@ public class JanusActivity extends Activity {
     private void init() {
         try {
             EGLContext con = VideoRendererGui.getEGLContext();
-            /*VideoRenderer.Callbacks[] renderers = new VideoRenderer.Callbacks[1];
-            renderers[0] = remoteRender;
-            videoRoomTest = new VideoRoomTest(localRender, renderers);
-            videoRoomTest.initializeMediaContext(this, true, true, true, con);
-            videoRoomTest.Start();
-            */
             echoTest = new EchoTest(localRender, remoteRender);
             echoTest.initializeMediaContext(this, true, true, true, con);
             echoTest.Start();

--- a/app/src/main/java/computician/janusclient/util/SystemUiHider.java
+++ b/app/src/main/java/computician/janusclient/util/SystemUiHider.java
@@ -54,6 +54,15 @@ public abstract class SystemUiHider {
     public static final int FLAG_HIDE_NAVIGATION = FLAG_FULLSCREEN | 0x4;
 
     /**
+     * A dummy no-op callback for use when there is no other listener set.
+     */
+    private static OnVisibilityChangeListener sDummyListener = new OnVisibilityChangeListener() {
+        @Override
+        public void onVisibilityChange(boolean visible) {
+        }
+    };
+
+    /**
      * The activity associated with this UI hider object.
      */
     protected Activity mActivity;
@@ -77,6 +86,12 @@ public abstract class SystemUiHider {
      */
     protected OnVisibilityChangeListener mOnVisibilityChangeListener = sDummyListener;
 
+    protected SystemUiHider(Activity activity, View anchorView, int flags) {
+        mActivity = activity;
+        mAnchorView = anchorView;
+        mFlags = flags;
+    }
+
     /**
      * Creates and returns an instance of {@link SystemUiHider} that is
      * appropriate for this device. The object will be either a
@@ -97,12 +112,6 @@ public abstract class SystemUiHider {
         } else {
             return new SystemUiHiderBase(activity, anchorView, flags);
         }
-    }
-
-    protected SystemUiHider(Activity activity, View anchorView, int flags) {
-        mActivity = activity;
-        mAnchorView = anchorView;
-        mFlags = flags;
     }
 
     /**
@@ -148,15 +157,6 @@ public abstract class SystemUiHider {
 
         mOnVisibilityChangeListener = listener;
     }
-
-    /**
-     * A dummy no-op callback for use when there is no other listener set.
-     */
-    private static OnVisibilityChangeListener sDummyListener = new OnVisibilityChangeListener() {
-        @Override
-        public void onVisibilityChange(boolean visible) {
-        }
-    };
 
     /**
      * A callback interface used to listen for system UI visibility changes.

--- a/app/src/main/java/computician/janusclient/util/SystemUiHiderHoneycomb.java
+++ b/app/src/main/java/computician/janusclient/util/SystemUiHiderHoneycomb.java
@@ -38,6 +38,44 @@ public class SystemUiHiderHoneycomb extends SystemUiHiderBase {
      */
     private boolean mVisible = true;
 
+    private View.OnSystemUiVisibilityChangeListener mSystemUiVisibilityChangeListener
+            = new View.OnSystemUiVisibilityChangeListener() {
+        @Override
+        public void onSystemUiVisibilityChange(int vis) {
+            // Test against mTestFlags to see if the system UI is visible.
+            if ((vis & mTestFlags) != 0) {
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
+                    // Pre-Jelly Bean, we must manually hide the action bar
+                    // and use the old window flags API.
+                    mActivity.getActionBar().hide();
+                    mActivity.getWindow().setFlags(
+                            WindowManager.LayoutParams.FLAG_FULLSCREEN,
+                            WindowManager.LayoutParams.FLAG_FULLSCREEN);
+                }
+
+                // Trigger the registered listener and cache the visibility
+                // state.
+                mOnVisibilityChangeListener.onVisibilityChange(false);
+                mVisible = false;
+
+            } else {
+                mAnchorView.setSystemUiVisibility(mShowFlags);
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
+                    // Pre-Jelly Bean, we must manually show the action bar
+                    // and use the old window flags API.
+                    mActivity.getActionBar().show();
+                    mActivity.getWindow().setFlags(
+                            0,
+                            WindowManager.LayoutParams.FLAG_FULLSCREEN);
+                }
+
+                // Trigger the registered listener and cache the visibility
+                // state.
+                mOnVisibilityChangeListener.onVisibilityChange(true);
+                mVisible = true;
+            }
+        }
+    };
     /**
      * Constructor not intended to be called by clients. Use
      * {@link SystemUiHider#getInstance} to obtain an instance.
@@ -99,43 +137,4 @@ public class SystemUiHiderHoneycomb extends SystemUiHiderBase {
     public boolean isVisible() {
         return mVisible;
     }
-
-    private View.OnSystemUiVisibilityChangeListener mSystemUiVisibilityChangeListener
-            = new View.OnSystemUiVisibilityChangeListener() {
-        @Override
-        public void onSystemUiVisibilityChange(int vis) {
-            // Test against mTestFlags to see if the system UI is visible.
-            if ((vis & mTestFlags) != 0) {
-                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
-                    // Pre-Jelly Bean, we must manually hide the action bar
-                    // and use the old window flags API.
-                    mActivity.getActionBar().hide();
-                    mActivity.getWindow().setFlags(
-                            WindowManager.LayoutParams.FLAG_FULLSCREEN,
-                            WindowManager.LayoutParams.FLAG_FULLSCREEN);
-                }
-
-                // Trigger the registered listener and cache the visibility
-                // state.
-                mOnVisibilityChangeListener.onVisibilityChange(false);
-                mVisible = false;
-
-            } else {
-                mAnchorView.setSystemUiVisibility(mShowFlags);
-                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
-                    // Pre-Jelly Bean, we must manually show the action bar
-                    // and use the old window flags API.
-                    mActivity.getActionBar().show();
-                    mActivity.getWindow().setFlags(
-                            0,
-                            WindowManager.LayoutParams.FLAG_FULLSCREEN);
-                }
-
-                // Trigger the registered listener and cache the visibility
-                // state.
-                mOnVisibilityChangeListener.onVisibilityChange(true);
-                mVisible = true;
-            }
-        }
-    };
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rules
squid:S1192 - String literals should not be duplicated.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava